### PR TITLE
fix: Reverting runner label to 24.04

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   docker_build:
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/lint-hadolint.yml
+++ b/.github/workflows/lint-hadolint.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   lint_hadolint:
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf

--- a/.github/workflows/lint-pylint.yml
+++ b/.github/workflows/lint-pylint.yml
@@ -7,7 +7,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   lint_pylint:
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/lint-ruff.yml
+++ b/.github/workflows/lint-ruff.yml
@@ -7,7 +7,7 @@ permissions:  # added using https://github.com/step-security/secure-repo
 
 jobs:
   lint_ruff:
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   pytest:
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Set up Python 3.13

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-24.04@sha256:f8b860e4f9036f2694571770da292642eebcc4c2ea0c70a1a9244c2a1d436cd9
+    runs-on: ubuntu-24.04
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ USER hivebox
 WORKDIR /home/hivebox
 COPY --from=ghcr.io/astral-sh/uv:0.7.2-alpine@sha256:c7b64811537bb43384150d3fa35c7cd42309d1ef45727d45df0619c14415b121 \
 /usr/local/bin/uv /usr/local/bin/uvx /bin/
-COPY --chown=hivebox:hivebox pyproject.toml .
-COPY --chown=hivebox:hivebox uv.lock .
+COPY --chown=hivebox:hivebox README.md pyproject.toml uv.lock ./
 COPY --chown=hivebox:hivebox src src/
 RUN uv sync --no-dev --locked
 EXPOSE 80/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ COPY --from=ghcr.io/astral-sh/uv:0.7.2-alpine@sha256:c7b64811537bb43384150d3fa35
 /usr/local/bin/uv /usr/local/bin/uvx /bin/
 COPY --chown=hivebox:hivebox pyproject.toml .
 COPY --chown=hivebox:hivebox uv.lock .
-RUN uv sync --no-dev --locked
 COPY --chown=hivebox:hivebox src src/
+RUN uv sync --no-dev --locked
 EXPOSE 80/tcp
 EXPOSE 80/udp
 ENTRYPOINT ["uv", "run", "fastapi"]

--- a/uv.lock
+++ b/uv.lock
@@ -510,7 +510,7 @@ wheels = [
 
 [[package]]
 name = "hive-box"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
Adding the hash doesn't seem to work on GitHub action since it's a runner label and not a docker image that is specified with the runs-on instruction.